### PR TITLE
[Bug] 게시물 저장 시 익명 여부에 따라 작성자 이름 저장 로직 수정

### DIFF
--- a/app/src/main/java/com/meezzi/localtalk/repository/PostSaveRepository.kt
+++ b/app/src/main/java/com/meezzi/localtalk/repository/PostSaveRepository.kt
@@ -25,10 +25,21 @@ class PostSaveRepository @Inject constructor(
     fun savePostWithImages(
         post: Post,
         imageUris: List<Uri>?,
+        isAnonymous: Boolean,
         onSuccess: (String, String, String) -> Unit,
         onFailure: (Exception) -> Unit,
     ) {
         val postId = db.collection("posts").document().id
+        val userId = currentUser?.uid ?: ""
+
+        if (isAnonymous) {
+            savePost(
+                postId = postId,
+                post = post.copy(authorName = "익명"),
+                onSuccess = { onSuccess(post.city, post.category.id, postId) },
+                onFailure = onFailure
+            )
+        } else {
 
         if (!imageUris.isNullOrEmpty()) {
             imageUris.forEach { uri ->

--- a/app/src/main/java/com/meezzi/localtalk/repository/PostSaveRepository.kt
+++ b/app/src/main/java/com/meezzi/localtalk/repository/PostSaveRepository.kt
@@ -40,18 +40,29 @@ class PostSaveRepository @Inject constructor(
                 onFailure = onFailure
             )
         } else {
+            db.collection("profiles")
+                .document(userId)
+                .get()
+                .addOnSuccessListener { document ->
+                    val nickname = document?.getString("nickname") ?: "닉네임 없음"
 
-        if (!imageUris.isNullOrEmpty()) {
-            imageUris.forEach { uri ->
-                uploadImage(uri, post.city, post.category.id, postId)
-            }
+                    if (!imageUris.isNullOrEmpty()) {
+                        imageUris.forEach { uri ->
+                            uploadImage(uri, post.city, post.category.id, postId)
+                        }
+                    }
+
+                    savePost(
+                        postId = postId,
+                        post = post.copy(authorName = nickname),
+                        onSuccess = { onSuccess(post.city, post.category.id, postId) },
+                        onFailure = onFailure
+                    )
+                }
+                .addOnFailureListener { exception ->
+                    onFailure(exception)
+                }
         }
-        savePost(
-            postId = postId,
-            post = post,
-            onSuccess = { onSuccess(post.city, post.category.id, postId) },
-            onFailure = onFailure
-        )
     }
 
     private fun uploadImage(

--- a/app/src/main/java/com/meezzi/localtalk/ui/addPost/AddPostViewModel.kt
+++ b/app/src/main/java/com/meezzi/localtalk/ui/addPost/AddPostViewModel.kt
@@ -84,13 +84,6 @@ class AddPostViewModel @Inject constructor(
 
         if (category != null) {
             viewModelScope.launch {
-
-                val authorName =
-                    if (isAnonymous.value) "익명"
-                    else {
-                        FirebaseAuth.getInstance().currentUser?.displayName
-                    }
-
                 val post = Post(
                     city = address,
                     category = category,
@@ -98,7 +91,7 @@ class AddPostViewModel @Inject constructor(
                     title = title.value,
                     content = content.value,
                     authorId = "",
-                    authorName = authorName,
+                    authorName = "",
                     isAnonymous = isAnonymous.value,
                     timestamp = Timestamp.now(),
                     postImageUrl = selectedImageUris.value.map { it.toString() },
@@ -108,6 +101,7 @@ class AddPostViewModel @Inject constructor(
                 postSaveRepository.savePostWithImages(
                     post = post,
                     imageUris = selectedImageUris.value,
+                    isAnonymous = isAnonymous.value,
                     onSuccess = { city, categoryId, postId ->
                         onSuccess(city, categoryId, postId)
                     },


### PR DESCRIPTION
### [문제 상황]
게시물을 저장할 때 구글 계정의 닉네임이 저장된다.

### [해결방안]
만약, 익명 여부가 참이라면 "익명"이라고 저장한다.
익명 여부가 거짓이라면 사용자 정보가 저장되어 있는 DB에서 닉네임을 가져온 후, 저장한다.